### PR TITLE
change -why behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ The `-from` flag shows *why* each dependency is included by printing,
 along with each package, the list of packages that depend on it.
 
 The `-why` flag can be used to explore just why a particular package has
-been included in the result - it will prune the results to only those
-packages which lie between the command-line-specified packages and the
-named package. This isn't much use unless you're doing it recursively
-or you don't print the `-from` results, so `-why` implies both `-a` and
-`-from`.
+been included in the result. By default, it shows a single dependency chain
+(a sequence of package names that import each other) from
+the listed packages to any package matched by the `=why` argument.
+If the -a flag is provided, it instead prints all packages
+that are part of any of those chains in `-from` style.
 
-Finally, the `-f` flag causes all the Go source files to be printed.
+Finally, the `-f` flag causes all the Go source file names to be printed.
 Since this is usually for whole-program greps or analysis, this also
 includes the source files in the packages specified on the command line.
 
@@ -61,9 +61,7 @@ the current directory and their dependencies.
 
 	$ showdeps -a -f ./... | xargs cat | wc -l
 
-Find out why net/http indirectly imports crypto/x509/pkix:
+Find out one reason why net/http indirectly imports crypto/x509/pkix:
 
-	$ showdeps -T  -why crypto/x509/pkix -stdlib net/http
-	crypto/tls net/http
-	crypto/x509 crypto/tls
-	crypto/x509/pkix crypto/x509
+	$ showdeps -T  -why crypto/x509/pkix net/http
+	net/http crypto/tls crypto/x509 crypto/x509/pkix

--- a/showdeps.go
+++ b/showdeps.go
@@ -18,11 +18,12 @@ import (
 
 var (
 	noTestDeps = flag.Bool("T", false, "exclude test dependencies")
-	all        = flag.Bool("a", false, "show all dependencies recursively (only test dependencies from the root packages are shown)")
+	all        = flag.Bool("a", false, "show all dependencies recursively (only test dependencies from the root packages are shown); when used with -why, show all intermediate packages")
 	std        = flag.Bool("stdlib", false, "show stdlib dependencies")
 	from       = flag.Bool("from", false, "show which dependencies are introduced by which packages")
 	why        = flag.String("why", "", "show only packages which import directly or indirectly the specified package (implies -a and -from)")
 	files      = flag.Bool("f", false, "list Go source files instead of packages (overrides -from and -why)")
+	maxChain   = flag.Int("n", 1, "max number of dependencies to print with -why (0 implies unlimited)")
 )
 
 var whyMatch func(string) bool
@@ -44,14 +45,21 @@ only, but the -a flag can be used to print all reachable dependencies.
 If the -from flag is specified, the package path on each line is followed
 by the paths of all the packages that depend on it.
 
-If the package argument to the -why flag is in the standard library,
-the -std flag is implied. The -why flag can also specify Go-command-style
-... wildcards.
+The -why flag finds out why a given dependency is present.  By default,
+it prints one arbitrary dependency chain for each package specified on
+the command line, showing why that package depends on the -why argument
+(which may also be a Go-command-style ... wildcard pattern).  If the
+package does not depend on the -why argument, it will not be printed. If
+the -a flag is specified, all packages in in any dependency chain will
+printed in -from style. The -n flag can be used to print up to a given
+maximum number of arbitrary dependency chains - every dependency chain
+printed will have at least one different package in it.
 
-If the -f flag is provided, instead of packages, showdeps will print
-all the Go source files in the package. It also includes the
-source of the packages specified directly on the command line,
-including their test files unless the -T flag is provided.
+If the -f flag is provided, instead of packages, showdeps will print all
+the Go source files in the package. It also includes the source of the
+packages specified directly on the command line, including their test
+files unless the -T flag is provided.
+
 `[1:]
 
 var cwd string
@@ -86,13 +94,20 @@ func main() {
 	} else {
 		cwd = d
 	}
+	recur := false
+	showAllWhy := false
 	if *why != "" {
-		*all = true
-		*from = true
+		recur = true
+		if *all {
+			*from = true
+			showAllWhy = true
+		}
 		if isStdlib(*why) {
 			*std = true
 		}
 		whyMatch = matchPattern(*why)
+	} else {
+		recur = *all
 	}
 
 	pkgs = gotool.ImportPaths(pkgs)
@@ -104,10 +119,9 @@ func main() {
 		}
 		rootPkgs[p.ImportPath] = true
 	}
-
 	allPkgs := make(map[string][]string)
-	for _, pkg := range pkgs {
-		if err := findImports(pkg, cwd, allPkgs, rootPkgs); err != nil {
+	for pkg := range rootPkgs {
+		if err := findImports(pkg, cwd, recur, allPkgs, rootPkgs); err != nil {
 			log.Fatalf("cannot find imports from %q: %v", pkg, err)
 		}
 	}
@@ -133,12 +147,17 @@ func main() {
 	}
 
 	result := make([]string, 0, len(allPkgs))
-	for name := range allPkgs {
+	for name, from := range allPkgs {
 		result = append(result, name)
+		sort.Strings(from)
 	}
 	w := bufio.NewWriter(os.Stdout)
 	defer w.Flush()
 	sort.Strings(result)
+	if *why != "" && !showAllWhy {
+		showNReasonsWhy(w, allPkgs, rootPkgs)
+		return
+	}
 	for _, r := range result {
 		switch {
 		case *files:
@@ -159,6 +178,64 @@ func main() {
 		default:
 			fmt.Fprintln(w, r)
 		}
+	}
+}
+
+// showNReasonsWhy shows up to maxChain lines for each package in the initial packages, each line showing
+// one dependency path from that package to a package matched by *why.
+func showNReasonsWhy(w io.Writer, allPkgs map[string][]string, rootPkgs map[string]bool) {
+	chains := make(map[string][][]string)
+	for pkg := range allPkgs {
+		if !whyMatch(pkg) {
+			continue
+		}
+		iterDepChains(pkg, rootPkgs, allPkgs, func(chain []string) {
+			pkg := chain[len(chain)-1]
+			if *maxChain > 0 && len(chains[pkg]) >= *maxChain {
+				return
+			}
+			chain1 := make([]string, len(chain))
+			for i, p := range chain {
+				chain1[len(chain)-i-1] = p
+			}
+			chains[pkg] = append(chains[pkg], chain1)
+		})
+	}
+	whyRoots := make([]string, 0, len(chains))
+	for pkg := range chains {
+		whyRoots = append(whyRoots, pkg)
+	}
+	sort.Strings(whyRoots)
+	for _, pkg := range whyRoots {
+		for _, chain := range chains[pkg] {
+			fmt.Fprintf(w, "%s\n", strings.Join(chain, " "))
+		}
+	}
+	return
+}
+
+// iterDepChains calls f with dependency chains to the given leaf package. The function is called with
+// leaf first and its importers sequentially after it.
+// It does not call f with *all* dependency chains, just the first chain that
+// it encounters that leads to a given package.
+func iterDepChains(leaf string, rootPkgs map[string]bool, allPkgs map[string][]string, f func(chain []string)) {
+	chain := make([]string, 1, len(allPkgs))
+	chain[0] = leaf
+	iterDepChains1(chain, make(map[string]bool), rootPkgs, allPkgs, f)
+}
+
+func iterDepChains1(chain []string, visited map[string]bool, rootPkgs map[string]bool, allPkgs map[string][]string, f func(chain []string)) {
+	pkg := chain[len(chain)-1]
+	if rootPkgs[pkg] {
+		f(chain)
+		return
+	}
+	if visited[pkg] {
+		return
+	}
+	visited[pkg] = true
+	for _, importer := range allPkgs[pkg] {
+		iterDepChains1(append(chain, importer), visited, rootPkgs, allPkgs, f)
 	}
 }
 
@@ -197,9 +274,9 @@ func isStdlib(pkg string) bool {
 	return !strings.Contains(strings.SplitN(pkg, "/", 2)[0], ".")
 }
 
-// findImports recursively adds all imported packages of given
-// package (packageName) to allPkgs map.
-func findImports(packageName, dir string, allPkgs map[string][]string, rootPkgs map[string]bool) error {
+// findImports recursively adds all imported packages by the given
+// package (packageName) to the allPkgs map.
+func findImports(packageName, dir string, recur bool, allPkgs map[string][]string, rootPkgs map[string]bool) error {
 	if packageName == "C" {
 		return nil
 	}
@@ -212,10 +289,10 @@ func findImports(packageName, dir string, allPkgs map[string][]string, rootPkgs 
 		if !*std && isStdlib(name) {
 			continue
 		}
-		alreadyDone := allPkgs[name] != nil
+		_, alreadyDone := allPkgs[name]
 		allPkgs[name] = append(allPkgs[name], pkg.ImportPath)
-		if *all && !alreadyDone {
-			if err := findImports(name, pkg.Dir, allPkgs, rootPkgs); err != nil {
+		if recur && !alreadyDone {
+			if err := findImports(name, pkg.Dir, recur, allPkgs, rootPkgs); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
I always found output of -why very hard to understand.
Usually all I want is to print just one example chain from package to dependency.

This change makes that the default -why behaviour.
The old behaviour is still available via -why -a.